### PR TITLE
Terraform code for ECS - for dashboard

### DIFF
--- a/terraform/README.MD
+++ b/terraform/README.MD
@@ -62,6 +62,6 @@ Before running the script, you need to set up your AWS credentials. Create a new
 | DB_NAME           | The name of the database.                              |
 | SCHEMA_NAME       | The name of the database schema.                       |
 | ETL_ECR_URI       | The URI for the ETL container repository in ECR.       |
-| ARCHIVE_ECR_URI  | The URI for the Archive container repository in ECR.    |
+| ARCHIVE_ECR_URI   | The URI for the Archive container repository in ECR.   |
 | DASHBOARD_ECR_URI | The URI for the dashboard container repository in ECR. |
 

--- a/terraform/README.MD
+++ b/terraform/README.MD
@@ -44,18 +44,21 @@ terraform destroy
 
 Before running the script, you need to set up your AWS credentials. Create a new file called `.terraform.tfvars` in the `terraform` directory and add the following lines, with your actual AWS keys and database details:
 
-| Variable         | Description                                      |
-|------------------|--------------------------------------------------|
-| AWS_ACCESS_KEY   | The access key for AWS authentication.           |
-| AWS_SECRET_KEY   | The secret key for AWS authentication.           |
-| C14_VPC          | The VPC (Virtual Private Cloud) ID.              |
-| C14_SUBNET_1     | The subnet id 1.                                 |
-| C14_SUBNET_2     | The subnet id 2.                                 |
-| C14_SUBNET_3     | The subnet id 3.                                 |
-| DB_HOST          | The hostname or IP address of the database.      |
-| DB_PORT          | The port number for the database connection.     |
-| DB_PASSWORD      | The password for the database user.              |
-| DB_USER          | The username for the database.                   |
-| DB_NAME          | The name of the database.                        |
-| SCHEMA_NAME      | The name of the database schema.                 |
-| ETL_ECR_URI      | The URI for the ETL container repository in ECR. |
+| Variable          | Description                                            |
+|-------------------|--------------------------------------------------------|
+| AWS_ACCESS_KEY    | The access key for AWS authentication.                 |
+| AWS_SECRET_KEY    | The secret key for AWS authentication.                 |
+| C14_VPC           | The VPC (Virtual Private Cloud) ID.                    |
+| C14_SUBNET_1      | The subnet id 1.                                       |
+| C14_SUBNET_2      | The subnet id 2.                                       |
+| C14_SUBNET_3      | The subnet id 3.                                       |
+| C14_CLUSTER       | The cluster for the ECS service.                       |
+| DB_HOST           | The hostname or IP address of the database.            |
+| DB_PORT           | The port number for the database connection.           |
+| DB_PASSWORD       | The password for the database user.                    |
+| DB_USER           | The username for the database.                         |
+| DB_NAME           | The name of the database.                              |
+| SCHEMA_NAME       | The name of the database schema.                       |
+| ETL_ECR_URI       | The URI for the ETL container repository in ECR.       |
+| DASHBOARD_ECR_URI | The URI for the dashboard container repository in ECR. |
+

--- a/terraform/README.MD
+++ b/terraform/README.MD
@@ -11,6 +11,7 @@ This directory focuses on **terraforming** all the AWS cloud services that are u
 ## Terraformed AWS services:
 * Lambda - to run the ETL pipeline for extracting plant metrics and uploading to the RDS. 
 * Event Bridge schedules - to schedule the ETL pipeline lambda for every minute.
+* ECS Service - to run the dashboard continuously.
   
 
 ## Installation

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -150,3 +150,121 @@ resource "aws_scheduler_schedule" "c14-runtime-terrors-plants-etl-schedule-tf" {
     role_arn = aws_iam_role.c14-runtime-terrors-plants-etl-scheduler_execution_role-tf.arn
   }
 }
+
+
+# --------------- ECS FARGATE SERVICE: DASHBAORD
+
+data "aws_ecs_cluster" "c14-cluster" {
+    cluster_name = var.C14_CLUSTER
+}
+
+data "aws_iam_role" "execution-role" {
+    name = "ecsTaskExecutionRole"
+}
+
+resource "aws_ecs_task_definition" "c14-runtime-terrors-plants-dashboard-ECS-task-def-tf" {
+  family                   = "c14-runtime-terrors-plants-dashboard-ECS-task-def-tf"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  execution_role_arn       = data.aws_iam_role.execution-role.arn
+  cpu                      = 1024
+  memory                   = 2048
+  container_definitions    = jsonencode([
+    {
+      name         = "c14-runtime-terrors-plants-dashboard-ECS-task-def-tf"
+      image        = var.DASHBOARD_ECR_URI
+      cpu          = 10
+      memory       = 512
+      essential    = true
+      portMappings = [
+        {
+            containerPort = 80
+            hostPort      = 80
+        },
+        {
+            containerPort = 8501
+            hostPort      = 8501       
+        }
+      ]
+      environment= [
+                {
+                    "name": "ACCESS_KEY",
+                    "value": var.AWS_ACCESS_KEY
+                },
+                {
+                    "name": "SECRET_ACCESS_KEY",
+                    "value": var.AWS_SECRET_KEY
+                },
+                {
+                    "name": "DB_NAME",
+                    "value": var.DB_NAME
+                },
+                {
+                    "name": "DB_USER",
+                    "value": var.DB_USER
+                },
+                {
+                    "name": "DB_PASSWORD",
+                    "value": var.DB_PASSWORD
+                },
+                {
+                    "name": "DB_HOST",
+                    "value": var.DB_HOST
+                },
+                {
+                    "name": "DB_PORT",
+                    "value": var.DB_PORT
+                },
+                {
+                    "name": "SCHEMA_NAME",
+                    "value": var.SCHEMA_NAME
+                }
+            ]
+            logConfiguration = {
+                logDriver = "awslogs"
+                options = {
+                    "awslogs-create-group"  = "true"
+                    "awslogs-group"         = "/ecs/c14-runtime-terrors-plants-ECS-task-def-tf"
+                    "awslogs-region"        = "eu-west-2"
+                    "awslogs-stream-prefix" = "ecs"
+                }
+            }
+    },
+  ])
+}
+
+resource "aws_security_group" "c14-runtime-terrors-plants-dashboard-sg-tf" {
+    name        = "c14-runtime-terrors-plants-dashboard-sg-tf"
+    description = "Security group for connecting to dashboard"
+    vpc_id      = data.aws_vpc.c14-vpc.id
+
+    egress {
+        from_port   = 0
+        to_port     = 0
+        protocol    = "-1"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+    ingress {
+        from_port   = 8501
+        to_port     = 8501
+        protocol    = "tcp"
+        cidr_blocks = ["0.0.0.0/0"]
+    }
+
+
+}
+
+resource "aws_ecs_service" "c14-runtime-terrors-plants-dashboard-service-tf" {
+    name            = "c14-runtime-terrors-plants-dashboard-service-tf"
+    cluster         = data.aws_ecs_cluster.c14-cluster.id
+    task_definition = aws_ecs_task_definition.c14-runtime-terrors-plants-dashboard-ECS-task-def-tf.arn
+    desired_count   = 1
+    launch_type     = "FARGATE" 
+    
+    network_configuration {
+        subnets          = [data.aws_subnet.c14-subnet-1, data.aws_subnet.c14-subnet-2, data.aws_subnet.c14-subnet-3] 
+        security_groups  = [aws_security_group.c14-runtime-terrors-plants-dashboard-sg-tf.id] 
+        assign_public_ip = true
+    }
+}
+

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -12,7 +12,6 @@ variable "AWS_REGION" {
 variable "C14_VPC"{
     type = string
 }
-
 variable "C14_SUBNET_1"{
     type = string
 }
@@ -20,6 +19,9 @@ variable "C14_SUBNET_2"{
     type = string
 }
 variable "C14_SUBNET_3"{
+    type = string
+}
+variable C14_CLUSTER{
     type = string
 }
 
@@ -44,5 +46,9 @@ variable "SCHEMA_NAME"{
 }
 
 variable "ETL_ECR_URI"{
+    type = string
+}
+
+variable "DASHBOARD_ECR_URI"{
     type = string
 }


### PR DESCRIPTION
1. Terraform code for ECS service, to allow for reusability and repeatability of code of resource.
2. Updated readme.md with guidance

closes #41 