### PR TITLE
fixing issue with null value discard row

### DIFF
--- a/pipeline/test_transform.py
+++ b/pipeline/test_transform.py
@@ -73,9 +73,11 @@ class TestTransformCleaning():
     def test_null_value_discard_row(self):
         """Function tests discarding of row with null temperature value."""
         test_data = {
+            "plant_id": [1, 2],
+            "name": ["test1", "test2"],
             "temperature": [None, 45],
             "soil_moisture": [21.34, 23.65]
         }
         df = check_for_null_vals(pd.DataFrame(test_data))
-        assert df.shape == (1, 2)
+        assert df.shape == (1, 4)
         assert not df.isnull().values.any()


### PR DESCRIPTION
There was a failing test (testing that a row is discarded if there is no name or plant id) that failed due to the test not having enough fields in the test_data dict. This has now been changed and should work.

Closes issue #65