### PR TITLE
fixing table of contents links

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Liverpool Natural History Museum (LNMH) employs an array of Raspberry Pi sensors
 ### Prerequisites:
 - Python 3.10 must be installed with pip3 for dependency installation.  
 
-### Installation
+### Installation:
 These instructions are for **macOS only**.
 
 1. **Clone the repository to your local machine using the following command**:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Prerequisites:
 - Python 3.10 must be installed with pip3 for dependency installation.  
 
 
-## Installation ⚙️
+### Installation ⚙️
 These instructions are for **macOS only**.
 
 1. **Clone the repository to your local machine using the following command**:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <details>
   <summary>Table of Contents 📝</summary>
   <ol>
-     <li>
+    <li>
       <a href="#about-the-project-">About The Project</a>
       <ul>
         <li><a href="#diagrams-">Diagrams</a></li>
@@ -14,8 +14,11 @@
     </li>
     <li>
       <a href="#getting-started-">Getting Started</a>
+      <ul>
+        <li><a href="#prerequisites">Prerequisites</a></li>
+        <li><a href="#installation-">Installation</a></li>
+      </ul>
     </li>
-    <li><a href="#installation-">Installation</a></li>
     <li>
       <a href="#requirements-">Requirements</a>
     </li>
@@ -53,11 +56,11 @@ Liverpool Natural History Museum (LNMH) employs an array of Raspberry Pi sensors
 
 
 ## Getting Started 🛠️ 
-Prerequisites:
+### Prerequisites:
 - Python 3.10 must be installed with pip3 for dependency installation.  
 
 
-## Installation ⚙️
+### Installation ⚙️
 These instructions are for **macOS only**.
 
 1. **Clone the repository to your local machine using the following command**:

--- a/README.md
+++ b/README.md
@@ -13,20 +13,19 @@
       </ul>
     </li>
     <li>
-      <a href="#-getting-started">Getting Started</a>
+      <a href="#getting-started-">Getting Started</a>
       <ul>
-        <li><a href="#prerequisites">Prerequisites</a></li>
         <li><a href="#installation-">Installation</a></li>
       </ul>
     </li>
     <li>
-      <a href="#-requirements">Requirements</a>
+      <a href="#requirements-">Requirements</a>
     </li>
     <li>
-      <a href="#-folders-explained">Folders Explained</a>
+      <a href="#folders-explained-">Folders Explained</a>
     </li>
     <li>
-      <a href="#-files-explained">Files Explained</a>
+      <a href="#files-explained-">Files Explained</a>
     </li>
     <li>
       <a href="#developers-">Developers</a>
@@ -55,7 +54,7 @@ Liverpool Natural History Museum (LNMH) employs an array of Raspberry Pi sensors
  [![Python][Python.com]][Python-url]
 
 
-## 🛠️ Getting Started
+## Getting Started 🛠️ 
 Prerequisites:
 - Python 3.10 must be installed with pip3 for dependency installation.  
 

--- a/README.md
+++ b/README.md
@@ -2,43 +2,41 @@
 ![Pytest Score](.github/badges/test.svg)
 # Liverpool Natural History Museum: Plant Health Monitoring System
 
-<!-- TABLE OF CONTENTS -->
 <details>
   <summary>Table of Contents 📝</summary>
   <ol>
     <li>
-      <a href="#about-the-project">About The Project</a>
+      <a href="#about-the-project-🌱">About The Project</a>
       <ul>
-        <li><a href="#Diagrams">Diagrams</a></li>
+        <li><a href="#diagrams-📊">Diagrams</a></li>
       </ul>
       <ul>
         <li><a href="#built-with">Built With</a></li>
       </ul>
     </li>
     <li>
-      <a href="#getting-started">Getting Started</a>
+      <a href="#🛠️-getting-started">Getting Started</a>
       <ul>
         <li><a href="#prerequisites">Prerequisites</a></li>
-        <li><a href="#installation">Installation</a></li>
+        <li><a href="#installation-⚙️">Installation</a></li>
       </ul>
     <li>
-    <a href="#Requirements">Requirements</a>
+      <a href="#requirements-📋">Requirements</a>
     </li>
     <li>
-    <a href="#folders-explained">Files Explained</a>
+      <a href="#folders-explained-📁">Folders Explained</a>
     </li>
     <li>
-    <a href="#files-explained">Folders Explained</a>
+      <a href="#files-explained-🗂️">Files Explained</a>
     </li>
     <li>
-    <a href="#developers">Developers</a>
+      <a href="#developers-👨🏽‍💻👩🏽‍💻">Developers</a>
     </li>
   </ol>
 </details>
 
 ## About the Project 🌱
 Liverpool Natural History Museum (LNMH) employs an array of Raspberry Pi sensors to monitor critical plant health metrics such as soil moisture and temperature across their conservatory. However, the museum is seeking to enhance its monitoring system by tracking the health of plants over time and providing real-time alerts for gardeners when there is a problem. This project delivers a fully-functioning cloud-based Extract Transform Load (ETL) pipeline incorporating short- and long-term data storage solutions. In addition, the project includes a dynamic dashboard which allows staff constant access to a source of continually updating information. 
-
 
 ### Diagrams 📊
 

--- a/README.md
+++ b/README.md
@@ -55,10 +55,9 @@ Liverpool Natural History Museum (LNMH) employs an array of Raspberry Pi sensors
  [![Python][Python.com]][Python-url]
 
 
-## Getting Started 🛠️ 
+## Getting Started 🛠️
 ### Prerequisites:
 - Python 3.10 must be installed with pip3 for dependency installation.  
-
 
 ### Installation ⚙️
 These instructions are for **macOS only**.

--- a/README.md
+++ b/README.md
@@ -14,9 +14,7 @@
     </li>
     <li>
       <a href="#getting-started-">Getting Started</a>
-      <ul>
-        <li><a href="#installation-">Installation</a></li>
-      </ul>
+      <a href="#installation-">Installation</a>
     </li>
     <li>
       <a href="#requirements-">Requirements</a>
@@ -59,7 +57,7 @@ Prerequisites:
 - Python 3.10 must be installed with pip3 for dependency installation.  
 
 
-### Installation ⚙️
+## Installation ⚙️
 These instructions are for **macOS only**.
 
 1. **Clone the repository to your local machine using the following command**:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
       <a href="#getting-started-">Getting Started</a>
       <ul>
         <li><a href="#prerequisites">Prerequisites</a></li>
-        <li><a href="#installation-">Installation</a></li>
+        <li><a href="#installation">Installation</a></li>
       </ul>
     </li>
     <li>
@@ -59,7 +59,7 @@ Liverpool Natural History Museum (LNMH) employs an array of Raspberry Pi sensors
 ### Prerequisites:
 - Python 3.10 must be installed with pip3 for dependency installation.  
 
-### Installation ⚙️
+### Installation
 These instructions are for **macOS only**.
 
 1. **Clone the repository to your local machine using the following command**:

--- a/README.md
+++ b/README.md
@@ -6,31 +6,31 @@
   <summary>Table of Contents 📝</summary>
   <ol>
     <li>
-      <a href="#about-the-project-🌱">About The Project</a>
+      <a href="#About-The-Project-🌱">About The Project</a>
       <ul>
-        <li><a href="#diagrams-📊">Diagrams</a></li>
+        <li><a href="#Diagrams-📊">Diagrams</a></li>
       </ul>
       <ul>
-        <li><a href="#built-with">Built With</a></li>
+        <li><a href="#Built-With">Built With</a></li>
       </ul>
     </li>
     <li>
-      <a href="#🛠️-getting-started">Getting Started</a>
+      <a href="#🛠️-Getting-Started">Getting Started</a>
       <ul>
-        <li><a href="#prerequisites">Prerequisites</a></li>
-        <li><a href="#installation-⚙️">Installation</a></li>
+        <li><a href="#Prerequisites">Prerequisites</a></li>
+        <li><a href="#Installation-⚙️">Installation</a></li>
       </ul>
     <li>
-      <a href="#requirements-📋">Requirements</a>
+      <a href="#Requirements-📋">Requirements</a>
     </li>
     <li>
-      <a href="#folders-explained-📁">Folders Explained</a>
+      <a href="#Folders-Explained-📁">Folders Explained</a>
     </li>
     <li>
-      <a href="#files-explained-🗂️">Files Explained</a>
+      <a href="#Eiles-Explained-🗂️">Files Explained</a>
     </li>
     <li>
-      <a href="#developers-👨🏽‍💻👩🏽‍💻">Developers</a>
+      <a href="#Developers-👨🏽‍💻👩🏽‍💻">Developers</a>
     </li>
   </ol>
 </details>

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ These folders are found this repository:
   This folder contains the infrastructure-as-code (IaC) setup using Terraform. It includes the configuration files to provision and manage cloud resources, required for the Plant Health Monitoring System. These resources are essential for setting up the cloud environment that supports the ETL pipeline and real-time dashboard.
 
 
-## Files Explained 🗂️
+## Files Explained🗂️
 These files are found in this repository:
 - **README.md**  
   This is the file you are currently reading, containing information about each file.   

--- a/README.md
+++ b/README.md
@@ -5,32 +5,31 @@
 <details>
   <summary>Table of Contents 📝</summary>
   <ol>
-    <li>
-      <a href="#About-The-Project-🌱">About The Project</a>
+     <li>
+      <a href="#about-the-project-">About The Project</a>
       <ul>
-        <li><a href="#Diagrams-📊">Diagrams</a></li>
-      </ul>
-      <ul>
-        <li><a href="#Built-With">Built With</a></li>
+        <li><a href="#diagrams-">Diagrams</a></li>
+        <li><a href="#built-with">Built With</a></li>
       </ul>
     </li>
     <li>
-      <a href="#🛠️-Getting-Started">Getting Started</a>
+      <a href="#-getting-started">Getting Started</a>
       <ul>
-        <li><a href="#Prerequisites">Prerequisites</a></li>
-        <li><a href="#Installation-⚙️">Installation</a></li>
+        <li><a href="#prerequisites">Prerequisites</a></li>
+        <li><a href="#installation-">Installation</a></li>
       </ul>
-    <li>
-      <a href="#Requirements-📋">Requirements</a>
     </li>
     <li>
-      <a href="#Folders-Explained-📁">Folders Explained</a>
+      <a href="#-requirements">Requirements</a>
     </li>
     <li>
-      <a href="#Eiles-Explained-🗂️">Files Explained</a>
+      <a href="#-folders-explained">Folders Explained</a>
     </li>
     <li>
-      <a href="#Developers-👨🏽‍💻👩🏽‍💻">Developers</a>
+      <a href="#-files-explained">Files Explained</a>
+    </li>
+    <li>
+      <a href="#developers-">Developers</a>
     </li>
   </ol>
 </details>

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Liverpool Natural History Museum (LNMH) employs an array of Raspberry Pi sensors
 
 
 ## Getting Started 🛠️
+
 ### Prerequisites:
 - Python 3.10 must be installed with pip3 for dependency installation.  
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
     </li>
     <li>
       <a href="#getting-started-">Getting Started</a>
-      <a href="#installation-">Installation</a>
     </li>
+    <li><a href="#installation-">Installation</a></li>
     <li>
       <a href="#requirements-">Requirements</a>
     </li>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
       </ul>
     </li>
     <li>
-      <a href="#getting-started-">Getting Started</a>
+      <a href="https://github.com/SurinaCS/lmnh-plant-sensors/blob/cf0a61daaeb11f05ec92ab97172d9e2ce51b836a/README.md#getting-started-%EF%B8%8F">Getting Started</a>
       <ul>
         <li><a href="#prerequisites">Prerequisites</a></li>
         <li><a href="#installation">Installation</a></li>
@@ -26,7 +26,7 @@
       <a href="#folders-explained-">Folders Explained</a>
     </li>
     <li>
-      <a href="#files-explained-">Files Explained</a>
+      <a href="https://github.com/SurinaCS/lmnh-plant-sensors/blob/cf0a61daaeb11f05ec92ab97172d9e2ce51b836a/README.md#files-explained%EF%B8%8F">Files Explained</a>
     </li>
     <li>
       <a href="#developers-">Developers</a>


### PR DESCRIPTION
The links in the table of contents should now move thepage to where the relevant section is.
Fixes issue #106 